### PR TITLE
Consolidate README.md files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,3 @@
 # Eclipse Platform™
 
-![splash](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform/master/platform/org.eclipse.platform/splash.png)
-
-Eclipse Platform is a comprehensive set of frameworks and common services that collectively provide a powerful software development infrastructure. It serves as the base framework for the Eclipse integrated development environment (IDE) and many other rich client applications.
-
-The platform includes a wide range of frameworks and common services that are essential to supporting the use of Eclipse as a component model. These services include a standard workbench user interface model and a portable native widget toolkit, which ensure that the user interface of Eclipse is consistent across different platforms. The project model allows for the management of resources and enables automatic resource delta management for incremental compilers and builders.
-
-Eclipse Platform also provides a language-independent debug infrastructure that enables developers to debug programs written in different languages. Additionally, the platform includes infrastructure for distributed multi-user versioned resource management, which allows for collaborative development and version control of resources.
-
-Overall, Eclipse Platform is an essential set of tools and services for developers who need a robust and flexible platform for building complex software applications. Its comprehensive set of frameworks and common services ensure that developers can create high-quality software that meets the needs of their users. As the base framework for the Eclipse IDE and many other rich client applications, Eclipse Platform has a proven track record of providing a stable and reliable development platform that supports the creation of powerful software applications.
-
-![workbench](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.common/master/bundles/org.eclipse.platform.doc.isv/guide/images/workbench.png)
-
-See also https://projects.eclipse.org/projects/eclipse.platform and https://eclipse.org/eclipse
-
-## Reporting issues
-
-The Eclipse Platform project is split into multiple Git repositories, which are all part of this organization. If you face an issue and have a sense of which particular GitHub repository is most related, you can open your issue against that repository. If you're unsure, you can open an issue against this current repositories and the issue will then be moved as best by maintainers.
-
-e.g.
-- [New SWT issue](https://github.com/eclipse-platform/eclipse.platform.swt/issues/new)
-- [New Platform issue](https://github.com/eclipse-platform/eclipse.platform.ui/issues/new)
-
-## Contributing
-
-[Contributions are always welcome!](https://github.com/eclipse-platform/.github/blob/main/CONTRIBUTING.md)
-
-Please bear in mind that this project is almost entirely developed by volunteers. If you do not provide the implementation yourself (or pay someone to do it for you), the bug might never get fixed. If it is a serious bug, other people than you might care enough to provide a fix.
-
-## Code of Conduct
-🤝 This project is governed by the Eclipse Foundation [Code of Conduct](https://github.com/eclipse-platform/.github/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report any unacceptable behavior to [conduct@eclipse-foundation.org](mailto:conduct@eclipse-foundation.org).
-
+See https://github.com/eclipse-platform

--- a/profile/README.md
+++ b/profile/README.md
@@ -5,9 +5,13 @@
 [Pull requests](https://github.com/pulls?user=eclipse-platform) |
 [Issues](https://github.com/issues?user=eclipse-platform)
 
-Eclipse Platform defines the set of frameworks and common services that collectively make up infrastructure required to support the use of Eclipse as a component model, as a Rich Client Platform (RCP) and as a comprehensive tool integration platform. These services and frameworks include a standard workbench user interface model and portable native widget toolkit, a project model for managing resources, automatic resource delta management for incremental compilers and builders, language-independent debug infrastructure, and infrastructure for distributed multi-user versioned resource management.
+Eclipse Platform is a comprehensive set of frameworks and common services that collectively provide a powerful software development infrastructure. It serves as the base framework for the [Eclipse integrated development environment IDE](https://www.eclipse.org/eclipseide/) and many other rich client applications.
 
-It is the base framework for the [Eclipse IDE](https://www.eclipse.org/eclipseide/) and many other applications.
+The platform includes a wide range of frameworks and common services that are essential to supporting the use of Eclipse as a component model. These services include a standard workbench user interface model and a portable native widget toolkit, which ensure that the user interface of Eclipse is consistent across different platforms. The project model allows for the management of resources and enables automatic resource delta management for incremental compilers and builders.
+
+Eclipse Platform also provides a language-independent debug infrastructure that enables developers to debug programs written in different languages. Additionally, the platform includes infrastructure for distributed multi-user versioned resource management, which allows for collaborative development and version control of resources.
+
+Overall, Eclipse Platform is an essential set of tools and services for developers who need a robust and flexible platform for building complex software applications. Its comprehensive set of frameworks and common services ensure that developers can create high-quality software that meets the needs of their users. As the base framework for the Eclipse IDE and many other rich client applications, Eclipse Platform has a proven track record of providing a stable and reliable development platform that supports the creation of powerful software applications.
 
 ![workbench](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.common/master/bundles/org.eclipse.platform.doc.isv/guide/images/workbench.png)
 
@@ -25,7 +29,11 @@ As you contribute more and more, you will eventually get nominated as a committe
 
 Before reporting an issue, please consider testing the latest build of Eclipse Platform or SDK. [This page](https://download.eclipse.org/eclipse/downloads/) lists latest builds, and links to downloadable product archives and p2 repositories; and if you're using Maven artifacts, snapshots of Eclipse project are available at https://repo.eclipse.org/content/repositories/eclipse-snapshots/ .
 
-The Eclipse Platform project codebase is split into multiple [repositories](https://github.com/orgs/eclipse-platform/repositories) owned by this organization. If you face an issue and have a sense of which particular GitHub repository is most related, you can open your issue against that particular repository. If you are unsure, you can open an [issue](https://github.com/eclipse-platform/.github/issues) against this current repository and the issue will then be moved as best by maintainers.
+The Eclipse Platform project codebase is split into multiple [repositories](https://github.com/orgs/eclipse-platform/repositories) owned by this organization. If you face an issue and have a sense of which particular GitHub repository is most related, you can open your issue against that particular repository, e.g.
+* [New SWT issue](https://github.com/eclipse-platform/eclipse.platform.swt/issues/new)
+* [New Platform issue](https://github.com/eclipse-platform/eclipse.platform.ui/issues/new)
+
+If you are unsure, you can open an [issue](https://github.com/eclipse-platform/.github/issues) against this current repository and the issue will then be moved as best by maintainers.
 
 For errors please provide Stacktrace or [minimal reproducer](https://stackoverflow.com/help/minimal-reproducible-example).
 
@@ -36,3 +44,5 @@ For performance issues attach sampling snapshot (for example with [visualvm](htt
 Contributions are always welcome!
 See [CONTRIBUTING.md](https://github.com/eclipse-platform/.github/blob/main/CONTRIBUTING.md)
 
+## Code of Conduct
+🤝 This project is governed by the Eclipse Foundation [Code of Conduct](https://github.com/eclipse-platform/.github/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report any unacceptable behavior to [conduct@eclipse-foundation.org](mailto:conduct@eclipse-foundation.org).

--- a/profile/README.md
+++ b/profile/README.md
@@ -27,7 +27,9 @@ As you contribute more and more, you will eventually get nominated as a committe
 
 ### Reporting issues
 
-Before reporting an issue, please consider testing the latest build of Eclipse Platform or SDK. [This page](https://download.eclipse.org/eclipse/downloads/) lists latest builds, and links to downloadable product archives and p2 repositories; and if you're using Maven artifacts, snapshots of Eclipse project are available at https://repo.eclipse.org/content/repositories/eclipse-snapshots/ .
+Before reporting an issue, please consider whether the issue still exists or as already been reported:
+* Find existing issues: https://github.com/issues?user=eclipse-platform
+* Test the latest build of Eclipse Platform or SDK: [This page](https://download.eclipse.org/eclipse/downloads/) lists latest builds, and links to downloadable product archives and p2 repositories; and if you're using Maven artifacts, snapshots of Eclipse project are available at https://repo.eclipse.org/content/repositories/eclipse-snapshots/ .
 
 The Eclipse Platform project codebase is split into multiple [repositories](https://github.com/orgs/eclipse-platform/repositories) owned by this organization. If you face an issue and have a sense of which particular GitHub repository is most related, you can open your issue against that particular repository, e.g.
 * [New SWT issue](https://github.com/eclipse-platform/eclipse.platform.swt/issues/new)


### PR DESCRIPTION
There are currently two `README.md` files: one for this repository and one in the `profile` folder to be presented at the organization's landing page.

The two files seem to be pretty redundant and have evolved independently. I propose to remove the redundancy by merging them into the one in the `profile` directory, as that is the one presented at the `eclipse-platform` organization. I have incorporated the changes made to the `README.md` of this repository into the one of the organization, which are in particular the changes proposed by @kthoms in #95. The contents of the local `README.md` contents are replaced with a link to the organization's `README.md`.

As a minor addition, I have added a hint to check existing issues when reporting a new one together with a link to the aggregated issues page of the organization.

Of course, let me know if I missed something and there is a reason for having separate `README.md` files.

Contributes to #119.