### PR TITLE
Elaborate recommendations for commit message

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,12 +123,29 @@ Here are the steps:
 
 ### Commit message recommendations
 
-  \<issue title\> \#\<issue number\>
+```
+<issue title> #<issue number>
+
+Short description/summary as to why this change is being made
   
-  Example: The eclipse-test-framework deliverable contains unsigned bundles \#32
-  
+Fixes httts://github.com/Full URL to issues/issue #
+```
+ 
+  Example: 
+
+```
+Make memory view cell editor visible on Linux GTK3 #132
+
+Since SWT change from GTK2 to GTK3 as its backend the cell
+editing in the memory view has not worked properly
+with the cell editor not visible. This change uses explicit
+setVisible rather than adjusting Z-order of the controls.
+
+Fixes https://github.com/eclipse-platform/eclipse.platform.debug/issues/132 
+```
+
   Again this is a recommendation on the issue title part. Instead of issue title, if needed provide a concise description of changes. 
-  Please do not forget to add the issue number to the commit message. This is used to link with GitHub issue.
+  Please do not forget to add the issue URL to the commit message. This is used to link with GitHub issue.
 
 ## Setting up development environment
 


### PR DESCRIPTION
There is a desire in the community to have full URLs in commit messages to fixed issues, rather than the short form of simply `#1234`.

This commit adds that recommendation and expands on the example of a desirable commit message format.

This came out of a conversation on https://github.com/eclipse-platform/eclipse.platform.debug/pull/138 where @iloveeclipse requested full URLs and I wanted a link to what a commit message should look like.