### PR TITLE
"Moved to" repositories still mentioned in CONTRIBUTING.md #237

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,10 +23,8 @@ more.
 
 The project issues and source code are maintained in [multiple GitHub repositories](https://github.com/orgs/eclipse-platform/repositories) like
 * https://github.com/eclipse-platform/eclipse.platform
-* https://github.com/eclipse-platform/eclipse.platform.releng
 * https://github.com/eclipse-platform/eclipse.platform.releng.aggregator
 * https://github.com/eclipse-platform/eclipse.platform.swt
-* https://github.com/eclipse-platform/eclipse.platform.swt.binaries
 * https://github.com/eclipse-platform/eclipse.platform.ui
 
 


### PR DESCRIPTION
Remove older repositories from CONTRIBUTING.md

Enhancement: https://github.com/eclipse-platform/.github/issues/237